### PR TITLE
Fix make build error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,10 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
+
+  - repo: local
+    hooks:
+      - id: mkdocs-build
+        name: mkdocs-build
+        entry: bash -c 'make build'
+        language: system

--- a/src/advanced/lambda_functions/__init__.py
+++ b/src/advanced/lambda_functions/__init__.py
@@ -3,3 +3,8 @@
 This module contains examples about lambda functions.
 
 """
+from .lambda_functions import (
+    filter_by_applying_function_to_elements,  # noqa: F401
+    get_list_of_fields_from_a_list_dict,  # noqa: F401
+    sort_a_list_of_dict_by_a_field,  # noqa: F401
+)


### PR DESCRIPTION
Add new pre-commit hook to execute make build,
so in case there is an error, you can fix before commiting.