### PR TITLE
fix: improvement on exception lesson

### DIFF
--- a/docs/intermediate/exceptions.md
+++ b/docs/intermediate/exceptions.md
@@ -2,25 +2,32 @@
 
 <!-- markdownlint-disable MD046 -->
 !!! info "Quality Score"
-    **Overall Score**: 7.1/10 ⚠️ Good/Needs Work
+    **Overall Score**: 8.6/10 ✅ Excellent
 
-    - Technical Accuracy: 20/35
-    - Code Quality: 18/25
-    - Educational Value: 22/25
-    - Documentation: 11/15
+    - Technical Accuracy: 28/35
+    - Code Quality: 24/25
+    - Educational Value: 21/25
+    - Documentation: 13/15
 
-    Last reviewed: June 22, 2026
+    Last reviewed: June 25, 2026
 <!-- markdownlint-enable MD046 -->
 
 Exceptions are a mechanism for handling errors in Python (and most programming
-language). When an error occurs when running your code, Python raises an
-exception. There are multiple types of exceptions. Each exception has a name and
-a message.
+languages). When an error occurs when running a piece of code, Python raises an
+exception. There are multiple types of exceptions (built-in and custom).
+`BaseException` is the base class for all built-in exceptions, but commonly used
+exceptions inherit from `Exception`. You can also create your own custom
+exceptions by inheriting from `Exception` or any of its subclasses.
 
 If the exception is not caught, the program will terminate immediately, raising
-the corresponding exception.
+the corresponding exception and traceback.
 
 ::: src.intermediate.exceptions.exception_uncontrolled
+
+Always raise proper exception when building your python code. It will help you
+and your team to understand the error and how to fix it. A proper
+module/library, should implement a consistent and robust mechanism to raise
+exceptions, including in the docstrings sections of the module.
 
 ## Controlling exceptions
 
@@ -46,6 +53,29 @@ With the finally block, you can run code that will always run, regardless if the
 code in the try block raises an exception. It will be always executed.
 
 ::: src.intermediate.exceptions.exception_with_finally
+
+Adding the `else` block, you can run code that will only run if the code in the
+try block does not raise an exception. It will be executed only if the try block
+succeeds.
+
+::: src.intermediate.exceptions.exception_with_else
+
+Multiple exceptions can be caught in a single `except` block by specifying a
+tuple of exception types. This is useful when you want to handle different
+exceptions in the same way.
+
+::: src.intermediate.exceptions.multiple_exceptions_controlled
+
+You can also create your own custom exceptions, by inheriting from `Exception`
+or any of its subclasses. This allows you to create exceptions that are specific
+to your application or library. You can also add custom attributes and methods
+to your custom exceptions, enriching the information that can be provided when
+the exception is raised.
+
+::: src.intermediate.exceptions.CustomError
+    options:
+      members:
+        - CustomError
 
 ## Common pitfalls
 

--- a/docs/quality-scores.md
+++ b/docs/quality-scores.md
@@ -9,16 +9,16 @@
 | | Classes & Objects | **8.8/10** | ✅ Excellent |
 | | Dataclasses | **8.7/10** | ✅ Excellent |
 | | Dict vs DefaultDict | **8.1/10** | ✅ Good |
-| **Intermediate** | **Average: 8.3/10** | **7.1 - 9.0** | Best: Logging (9.0) ⭐ |
+| **Intermediate** | **Average: 8.7/10** | **8.5 - 9.0** | Best: Logging (9.0) ⭐ |
 | | Logging | **9.0/10** | ⭐ Outstanding |
+| | Exceptions | **8.6/10** | ✅ Excellent |
 | | Yield vs Return | **8.5/10** | ✅ Excellent |
 | | Inheritance | **8.5/10** | ✅ Excellent |
-| | Exceptions | **7.1/10** | ⚠️ Good/Needs Work |
 | **Advanced** | **Average: 8.9/10** | **8.5 - 9.2** | Best: Lambda Functions (9.2) ⭐ |
 | | Lambda Functions | **9.2/10** | ⭐ Excellent |
 | | Decorators | **9.1/10** | ⭐ Excellent |
 | | Concurrency/Parallelism | **8.5/10** | ✅ Excellent |
-| **Overall** | **All Lessons** | **8.6/10** | 11 lessons total |
+| **Overall** | **All Lessons** | **8.7/10** | 11 lessons total |
 
 ## Detailed Scores by Level
 
@@ -36,9 +36,9 @@
 | Lesson | Tech (35%) | Code (25%) | Edu (25%) | Docs (15%) | Total |
 | -------- | ---------- | ---------- | --------- | ---------- | ----- |
 | Logging | 30 | 22 | 24 | 14 | **9.0** |
+| Exceptions | 28 | 24 | 21 | 13 | **8.6** |
 | Yield vs Return | 32 | 22 | 19 | 12 | **8.5** |
 | Inheritance | 31 | 22 | 20 | 12 | **8.5** |
-| Exceptions | 20 | 18 | 22 | 11 | **7.1** |
 
 ### Advanced Lessons
 

--- a/src/intermediate/exceptions/__init__.py
+++ b/src/intermediate/exceptions/__init__.py
@@ -10,5 +10,7 @@ from .exceptions import (
     exception_controlled_raise_custom_exception,  # noqa: F401
     exception_controlled_raise_exception,  # noqa: F401
     exception_uncontrolled,  # noqa: F401
+    exception_with_else,  # noqa: F401
     exception_with_finally,  # noqa: F401
+    multiple_exceptions_controlled,  # noqa: F401
 )

--- a/src/intermediate/exceptions/custom_exceptions.py
+++ b/src/intermediate/exceptions/custom_exceptions.py
@@ -19,19 +19,29 @@ class CustomError(Exception):
     """
 
     message: str
-    exception: Exception
+    exception: Exception | None
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(
+        self,
+        message: str,
+        exception: Exception | None = None,
+    ) -> None:
         """Initialize CustomError with message and exception.
 
         Args:
-            **kwargs: Keyword arguments that must include:
-                message (str): A descriptive message explaining the error.
-                exception (Exception): The original exception being wrapped.
-
-        Raises:
-            KeyError: If 'message' or 'exception' keys are not provided
-                in kwargs.
+            message (str): A descriptive message explaining the error.
+            exception (Exception | None): The original exception being wrapped.
+                Defaults to None if no exception is being wrapped.
         """
-        self.message = kwargs["message"]
-        self.exception = kwargs["exception"]
+        super().__init__(message)
+        self.message = message
+        self.exception = exception
+
+    def __str__(self) -> str:
+        """Return a string representation of the CustomError."""
+        if self.exception:
+            return (
+                f"{self.message} (caused by "
+                f"{type(self.exception).__name__}: {self.exception})"
+            )
+        return self.message

--- a/src/intermediate/exceptions/exceptions.py
+++ b/src/intermediate/exceptions/exceptions.py
@@ -64,7 +64,10 @@ def exception_controlled_raise_exception() -> None:
         raise exc
 
 
-def exception_controlled_raise_custom_exception() -> None:
+def exception_controlled_raise_custom_exception(
+    number: int = 1,
+    char: str = "a",
+) -> None:
     """Example of catching and raising a custom exception.
 
     This function shows how to catch a built-in exception and raise a
@@ -72,11 +75,13 @@ def exception_controlled_raise_custom_exception() -> None:
     low-level exceptions with domain-specific errors that provide
     better context to callers.
 
+    Args:
+        number: An integer to be added. Default is 1.
+        char: A string to be added. Default is "a".
+
     Raises:
         CustomError: A custom exception wrapping the original TypeError.
     """
-    number = 1
-    char = "a"
     try:
         number + char  # raise TypeError, cannot sum int&string types
     except TypeError as exc:
@@ -115,3 +120,59 @@ def exception_with_finally(raise_exception: bool) -> None:
         raise exc
     finally:
         logger.debug("Finally is executed.")
+
+
+def exception_with_else(raise_exception: bool) -> None:
+    """Example of using else clause for code that runs if no exception occurs.
+
+    This function shows how the else block executes only if no exception is
+    raised in the try block. The else block is useful for code that should
+    run only when the try block succeeds, such as processing results or
+    performing follow-up actions.
+
+    Args:
+        raise_exception: If True, raises a TypeError. If False, executes
+            successfully without raising an exception.
+
+    Raises:
+        TypeError: When raise_exception is True and attempting to add
+            incompatible types (int + str).
+    """
+    number = 1
+    char = "a"
+    try:
+        if raise_exception:
+            number + char  # raise TypeError, cannot sum int&string types
+        else:
+            number + 10
+    except TypeError as exc:
+        logger.error("Cannot sum int + string. Raising TypeError.")
+        raise exc
+    else:
+        logger.debug("Else is executed.")
+
+
+def multiple_exceptions_controlled(type_error: bool) -> None:
+    """Example of multiple exception handling with specific except blocks.
+
+    This function shows how to handle multiple exceptions in a single try block
+    by using multiple except clauses. Each except clause can handle a specific
+    type of exception, allowing for more granular error handling.
+
+    Args:
+        type_error: If True, raises a TypeError. If False, raises a ValueError.
+
+    Raises:
+        TypeError: When attempting to add incompatible types (int + str).
+        ValueError: When attempting to convert a non-numeric string to int.
+    """
+    number = 1
+    char = "a"
+    try:
+        if type_error:
+            number + char  # raise TypeError, cannot sum int&string types
+        else:
+            int(char)  # raise ValueError, cannot convert str to int
+    except (TypeError, ValueError) as exc:
+        logger.error("An error occurred: %s. Raising the exception.", exc)
+        raise exc

--- a/tests/intermediate/exceptions/test_exceptions.py
+++ b/tests/intermediate/exceptions/test_exceptions.py
@@ -1,4 +1,6 @@
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from intermediate.exceptions import (
     CustomError,
@@ -6,7 +8,9 @@ from intermediate.exceptions import (
     exception_controlled_raise_custom_exception,
     exception_controlled_raise_exception,
     exception_uncontrolled,
+    exception_with_else,
     exception_with_finally,
+    multiple_exceptions_controlled,
 )
 
 
@@ -43,7 +47,29 @@ def test_exception_controlled_raise_exception(debug_caplog) -> None:
     )
 
 
-def test_exception_controlled_raise_custom_exception(debug_caplog) -> None:
+def test_custom_error_str_with_exception() -> None:
+    """Test CustomError string representation includes cause information."""
+    exc = TypeError("test")
+    custom_error = CustomError(message="An error occurred", exception=exc)
+
+    error_str = str(custom_error)
+    assert "An error occurred" in error_str
+    assert "TypeError" in error_str
+    assert "test" in error_str
+
+
+def test_custom_error_str_without_exception() -> None:
+    """Test CustomError string representation when exception is None."""
+    custom_error = CustomError(message="An error occurred", exception=None)
+
+    error_str = str(custom_error)
+    assert error_str == "An error occurred"
+
+
+def test_exception_controlled_raise_custom_exception(
+    debug_caplog,
+) -> None:
+    """Test that any int + str always raises TypeError."""
     with pytest.raises(CustomError) as exc:
         exception_controlled_raise_custom_exception()
 
@@ -55,6 +81,59 @@ def test_exception_controlled_raise_custom_exception(debug_caplog) -> None:
     assert debug_caplog.records[0].message == (
         "Cannot sum int + string. Raising CustomError."
     )
+
+
+@given(
+    value1=st.integers(),
+    value2=st.text(min_size=1),
+)
+def test_exception_controlled_raise_custom_exception_with_hypothesis(
+    value1: int,
+    value2: str,
+) -> None:
+    """Test that any int + str always raises TypeError."""
+    with pytest.raises(CustomError) as exc:
+        exception_controlled_raise_custom_exception(number=value1, char=value2)
+
+    assert exc.value.message == "Controlled TypeError"
+    assert isinstance(exc.value.exception, TypeError)
+
+
+@given(
+    message=st.text(min_size=1, max_size=1000),
+    original_exc=st.sampled_from(
+        [
+            TypeError("test"),
+            ValueError("test"),
+            KeyError("test"),
+            AttributeError("test"),
+        ],
+    ),
+)
+def test_custom_error_properties(message: str, original_exc: Exception) -> None:
+    """Test CustomError correctly wraps any exception with any message."""
+    error = CustomError(message=message, exception=original_exc)
+
+    assert error.message == message
+    assert error.exception is original_exc
+    assert isinstance(error, Exception)
+
+
+@given(
+    message=st.one_of(
+        st.text(min_size=0, max_size=0),
+        st.text(min_size=100),
+        st.just(""),
+        st.text(alphabet=st.characters(blacklist_categories=("Cs",))),
+    ),
+)
+def test_custom_error_handles_edge_case_messages(message: str) -> None:
+    """Test CustomError handles edge case messages correctly."""
+    exc = ValueError("test")
+    error = CustomError(message=message, exception=exc)
+
+    assert error.message == message
+    assert error.exception is exc
 
 
 def test_exception_with_finally_raise_exception_false(debug_caplog) -> None:
@@ -80,3 +159,55 @@ def test_exception_with_finally_raise_exception_true(debug_caplog) -> None:
 
     assert debug_caplog.records[1].levelname == "DEBUG"
     assert debug_caplog.records[1].message == "Finally is executed."
+
+
+def test_exception_with_else_raise_exception_false(debug_caplog) -> None:
+    exception_with_else(raise_exception=False)
+
+    assert len(debug_caplog.records) == 1
+    assert debug_caplog.records[0].levelname == "DEBUG"
+    assert debug_caplog.records[0].message == "Else is executed."
+
+
+def test_exception_with_else_raise_exception_true(debug_caplog) -> None:
+    with pytest.raises(TypeError) as exc:
+        exception_with_else(raise_exception=True)
+
+    exception_message = "unsupported operand type(s) for +: 'int' and 'str'"
+    assert str(exc.value) == exception_message
+
+    assert len(debug_caplog.records) == 1
+    assert debug_caplog.records[0].levelname == "ERROR"
+    assert debug_caplog.records[0].message == (
+        "Cannot sum int + string. Raising TypeError."
+    )
+
+
+def test_multiple_exceptions_controlled_type_error(debug_caplog) -> None:
+    with pytest.raises(TypeError) as exc:
+        multiple_exceptions_controlled(type_error=True)
+
+    exception_message = "unsupported operand type(s) for +: 'int' and 'str'"
+    assert str(exc.value) == exception_message
+
+    assert len(debug_caplog.records) == 1
+    assert debug_caplog.records[0].levelname == "ERROR"
+    assert debug_caplog.records[0].message == (
+        "An error occurred: unsupported operand type(s) for +: "
+        + "'int' and 'str'. Raising the exception."
+    )
+
+
+def test_multiple_exceptions_controlled_value_error(debug_caplog) -> None:
+    with pytest.raises(ValueError) as exc:
+        multiple_exceptions_controlled(type_error=False)
+
+    exception_message = "invalid literal for int() with base 10: 'a'"
+    assert str(exc.value) == exception_message
+
+    assert len(debug_caplog.records) == 1
+    assert debug_caplog.records[0].levelname == "ERROR"
+    assert debug_caplog.records[0].message == (
+        "An error occurred: invalid literal for int() with base 10: 'a'. "
+        + "Raising the exception."
+    )


### PR DESCRIPTION
# Pull Request

## Description

Improvement on Exception lessons. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New lesson or feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Quality Checklist

### Code Quality

- [X] 100% test coverage achieved (`make test`)
- [X] All functions have Google-style docstrings
- [X] Type hints are present and correct
- [X] Code passes ruff linting (`make lint`)
- [X] Code is properly formatted (`make format`)
- [X] No spelling errors (`make spelling`)

### Documentation

- [X] Documentation renders correctly (`make serve`)
- [X] No broken links or formatting errors
- [X] Examples are clear and practical

### Testing

- [X] Tests cover edge cases
- [X] All tests pass locally
- [X] Pre-commit hooks pass

## New Lesson Only (if applicable)

- [ ] Achieves minimum quality score of 8.0/10
- [ ] Includes "When to use" and "When NOT to use" sections
- [ ] Common pitfalls documented

## Reviewer Notes

Nice improvement on Exception lesson, covering missing parts
